### PR TITLE
Adding sitemap split and max length options.

### DIFF
--- a/example/server.js
+++ b/example/server.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const Hapi = require('hapi');
+
+const server = new Hapi.Server({ port: 8081, debug: { log: ['*'] } });
+
+const start = async function() {
+  await server.register({
+    plugin: require('../'),
+    options: {
+      maxPerPage: 5,
+      dynamicRoutes: (slug) => [
+        '/slug-one',
+        '/slug-two',
+        '/slug-three',
+        '/slug-four',
+        '/slug-five',
+        '/slug-six',
+        '/slug-seven',
+        '/slug-eight',
+        '/slug-nine',
+        '/slug-ten',
+        '/slug-eleven',
+        '/slug-twelve'
+      ]
+    }
+  });
+
+  server.route({
+    method: 'GET',
+    path: '/handy-dandy',
+    config: {
+      plugins: {
+        sitemap: true
+      }
+    },
+    handler(request, h) {
+      return 'handy';
+    }
+  });
+
+  server.route({
+    method: 'GET',
+    path: '/handy/{fruits}',
+    config: {
+      plugins: {
+        sitemap: {
+          file: 'handy'
+        }
+      }
+    },
+    handler(request, h) {
+      return 'handy';
+    }
+  });
+
+  await server.start();
+  server.log(['notice'], `server running at ${server.info.uri}`);
+};
+
+start();
+

--- a/lib/generateIndex.js
+++ b/lib/generateIndex.js
@@ -1,0 +1,12 @@
+const xml = require('./xml.js');
+
+module.exports = (pageCount, file, protocol, options, request, h) => {
+  const pages = [];
+  for (let i = 1; i <= pageCount; i++) {
+    pages.push({
+      url: `${protocol}://${request.info.host}/sitemap-${file}-${i}.${request.params.type}`
+    });
+  }
+
+  return xml(pages, h, options, 'sitemapindex', 'sitemap');
+};

--- a/lib/getRoutes.js
+++ b/lib/getRoutes.js
@@ -1,8 +1,10 @@
 module.exports = async (server, options, request) => {
   const routeTable = server.table();
-  const results = [];
+  const results = {
+    main: []
+  };
 
-  const skip = ['/favicon.ico', '/sitemap.{type}'];
+  const skip = ['/favicon.ico', '/sitemap{suffix?}.{type}'];
 
   const parseRoute = async (table) => {
     if (request.query.all !== '1' && !table.settings.plugins.sitemap) {
@@ -21,8 +23,11 @@ module.exports = async (server, options, request) => {
     if (skip.includes(table.path)) {
       return;
     }
-    const pluginSettings = table.settings.plugins.sitemap;
-
+    const pluginSettings = table.settings.plugins.sitemap || {};
+    const file = pluginSettings.file || 'main';
+    if (!results[file]) {
+      results[file] = [];
+    }
     const protocol = options.forceHttps ? 'https' : request.server.info.protocol;
 
     if (table.path.indexOf('{') !== -1) {
@@ -45,7 +50,7 @@ module.exports = async (server, options, request) => {
             }
             // add the route if it is not excluded:
             if (!options.excludeUrls.includes(obj.path)) {
-              results.push(obj);
+              results[file].push(obj);
             }
           });
         }
@@ -74,7 +79,7 @@ module.exports = async (server, options, request) => {
         }
         Object.assign(page, metadata);
       }
-      results.push(page);
+      results[file].push(page);
     }
     return;
   };

--- a/lib/xml.js
+++ b/lib/xml.js
@@ -1,13 +1,13 @@
-module.exports = (pages, h, pluginOptions) => {
+module.exports = (pages, h, pluginOptions, parentElem = 'urlset', childElem = 'url') => {
   const xml = `<?xml version="1.0" encoding="UTF-8"?>
-    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <${parentElem} xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
       ${pages.map((page) => {
     const loc = `<loc>${page.url}</loc>`;
     const lastmod = page.lastmod ? `<lastmod>${page.lastmod}</lastmod>` : '';
     const changefreq = page.changefreq ? `<changefreq>${page.changefreq}</changefreq>` : '';
     const priority = page.priority ? `<priority>${page.priority}</priority>` : '';
-    return `<url>${loc}${lastmod}${changefreq}${priority}</url>`;
+    return `<${childElem}>${loc}${lastmod}${changefreq}${priority}</${childElem}>`;
   }).join('')}
-    </urlset>`;
+    </${parentElem}>`;
   return h.response(xml).type('text/xml');
 };

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "author": "First+Third",
   "license": "MIT",
   "dependencies": {
+    "boom": "^7.2.0",
     "joi": "^13.1.0",
     "lodash.groupby": "^4.6.0",
     "lodash.sortby": "^4.7.0"
@@ -28,7 +29,7 @@
     "eslint-plugin-import": "^2.8.0",
     "handlebars": "^4.0.11",
     "hapi": "^17.2.0",
-    "tap": "^11.0.1",
+    "tap": "^12.0.1",
     "vision": "^5.3.1"
   }
 }


### PR DESCRIPTION
- Adds route config option `file` that will assign that route (or all dynamic routes) to a separate sitemap named `sitemap-{file}.xml`
- Adds a config option `maxPerPage` that will split a sitemap up into separate sitemaps based upon the max size. Auto generates a sitemap index file (for xml only) for the root path.